### PR TITLE
Improve algo

### DIFF
--- a/hydra_agent/classes_objects.py
+++ b/hydra_agent/classes_objects.py
@@ -239,5 +239,4 @@ class ClassEndpoints:
             # set edge between the entrypoint and the class endpoint.
             self.addEdge(entrypoint_node, "has" + endpoint, class_object_node)
             node_alias[str(endpoint)] = class_object_node
-            endpoint_property_list[endpoint] = property_list
         self.connect_nodes(endpoint_property_list, node_alias)

--- a/hydra_agent/hydra_graph.py
+++ b/hydra_agent/hydra_graph.py
@@ -55,7 +55,6 @@ class InitialGraph:
             alias="Entrypoint",
             properties=entrypoint_properties)
         self.redis_graph.add_node(entrypoint_node)
-        redis_connection.set("EntryPoint", entrypoint_properties)
         return self.get_apistructure(entrypoint_node, api_doc)
 
 


### PR DESCRIPTION
Fixes #83 
This implementation works by creating a dictionary local to the `endpointclasses` method. The dictionary has aliases of the nodes as keys and the corresponding graph nodes as values. Then it uses another method `connect_nodes`  which takes in the dictionary as well as the `endpoint_property_list` as argument and adds edges between the nodes. This way it does not have to traverse through the whole graph (which contains `collectionEndpoints` as well while the dictionary only contains concerned `classEndpoints`). Although the space complexity of this method is greater than the current implementation but the time complexity is reduced (thanks to python's dictionary.get() method's average case time complexity of O(1)).

@Mec-iS @sandeepsajan0 kindly review.