### PR TITLE
Duplicate Nodes on commit

### DIFF
--- a/hydra_agent/querying_mechanism.py
+++ b/hydra_agent/querying_mechanism.py
@@ -62,6 +62,8 @@ class HandleData:
             if count % 2 != 0:
                 for obj1 in objects:
                     for obj in obj1:
+                        if obj is None:
+                            continue
                         string = obj.decode('utf-8')
                         map_string = map(str.strip, string.split(','))
                         property_list = list(map_string)

--- a/hydra_agent/redis_core/classes_objects.py
+++ b/hydra_agent/redis_core/classes_objects.py
@@ -179,13 +179,8 @@ class ClassEndpoints:
                 endpoint_property,
                 no_endpoint_property,
                 api_doc)
-        # delete all the old data that has saved in Redis using redis_graph.
-        # It will remove duplicate data from Redis.
-        for key in redis_connection.keys():
-            if "fs:" not in key.decode("utf8"):
-                redis_connection.delete(key)
         # save the new data.
-        self.redis_graph.commit()
+        self.redis_graph.flush()
 
     def endpointclasses(
             self,

--- a/hydra_agent/redis_core/collections_endpoint.py
+++ b/hydra_agent/redis_core/collections_endpoint.py
@@ -198,13 +198,8 @@ class CollectionEndpoints:
             url,
             redis_connection
         )
-        # delete all the old data that has saved in Redis using redis_graph.
-        # It will remove duplicate data from Redis.
-        for key in redis_connection.keys():
-            if "fs:" not in key.decode("utf8"):
-                redis_connection.delete(key)
         # save the new data.
-        self.redis_graph.commit()
+        self.redis_graph.flush()
 #        for node in self.redis_graph.nodes.values():
 #            print("\n",node.alias)
 

--- a/hydra_agent/redis_core/graphutils.py
+++ b/hydra_agent/redis_core/graphutils.py
@@ -119,9 +119,10 @@ class GraphUtils:
         edge = Edge(source_node, predicate, dest_node)
         self.redis_graph.add_edge(edge)
 
-    def commit(self) -> None:
-        """Commit the changes made to the Graph to Redis"""
-        self.redis_graph.commit()
+    def flush(self) -> None:
+        """Commit the changes made to the Graph to Redis and reset/flush
+        the Nodes and Edges to be added in the next commit"""
+        self.redis_graph.flush()
 
     def process_result(self, result: list) -> list:
         """

--- a/hydra_agent/redis_core/graphutils_operations.py
+++ b/hydra_agent/redis_core/graphutils_operations.py
@@ -60,7 +60,8 @@ class GraphOperations():
             self.graph_utils.add_node("objects" + resource['@type'],
                                       resource['@type'] + resource_id,
                                       resource)
-            self.graph_utils.commit()
+            # Commits the graph
+            self.graph_utils.flush()
 
             # Creating relation between collection node and member
             self.graph_utils.create_relation(label_source="collection",


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
Fixes 
https://github.com/HTTP-APIs/hydra-python-agent/issues/24
https://github.com/HTTP-APIs/hydra-python-agent/pull/44#issuecomment-407723686


### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
Working on https://github.com/HTTP-APIs/hydra-python-agent/issues/113 I detected an inconsistency of having duplicate nodes when interacting multiple times with the Graph, investigating I found that @Sandeep and @xadahiya had the same problem last year in the issues and Sandeep solved by deleting all the nodes and re-inserting them which is computationally expensive, so I fixed it around the repo.

### Obs
So, for future references basically redis_graph.commit() keeps the nodes/relationships internally, redis_graph.flush() commit nodes and relationships and delete them. Commit should be used to create the whole graph, flush to make additions.

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->