### PR TITLE
Server searching by type and properties

### DIFF
--- a/hydra_agent/agent.py
+++ b/hydra_agent/agent.py
@@ -1,4 +1,4 @@
-import logging
+import logging, sys
 from hydra_agent.redis_core.redis_proxy import RedisProxy
 from hydra_agent.redis_core.graphutils_operations import GraphOperations
 from hydra_agent.redis_core.graph_init import InitialGraph
@@ -41,7 +41,8 @@ class Agent(Session):
         self.redis_connection.sadd("fs:url", self.entrypoint_url)
 
     def get(self, url: str = None, resource_type: str = None,
-            filters: dict = {}, cached_limit: int = 10) -> Union[dict, list]:
+            filters: dict = {},
+            cached_limit: int = sys.maxsize) -> Union[dict, list]:
         """READ Resource from Server/cached Redis
         :param url: Resource URL to be fetched
         :param resource_type: Resource object type

--- a/hydra_agent/redis_core/graphutils.py
+++ b/hydra_agent/redis_core/graphutils.py
@@ -135,18 +135,19 @@ class GraphUtils:
         if not result.result_set:
             return []
 
-        for record in result.result_set[0][:]:
-            new_record = {}
-            if record is None:
-                return
-            new_record = record.properties
-            if new_record:
-                if 'id' in new_record:
-                    new_record['@id'] = new_record.pop('id')
-                    new_record['@type'] = new_record.pop('type')
-                if 'context' in new_record:
-                    new_record['@context'] = new_record.pop('context')
-                response_json_list.append(new_record)
+        for return_alias in result.result_set:
+            for record in return_alias[:]:
+                new_record = {}
+                if record is None:
+                    return
+                new_record = record.properties
+                if new_record:
+                    if 'id' in new_record:
+                        new_record['@id'] = new_record.pop('id')
+                        new_record['@type'] = new_record.pop('type')
+                    if 'context' in new_record:
+                        new_record['@context'] = new_record.pop('context')
+                    response_json_list.append(new_record)
 
         return response_json_list
 

--- a/hydra_agent/redis_core/graphutils.py
+++ b/hydra_agent/redis_core/graphutils.py
@@ -31,7 +31,7 @@ class GraphUtils:
         :return: Corresponding Nodes
         """
         query = "MATCH(p{})".format(match)
-        if where is not None:
+        if where:
             query += " WHERE(p.{})".format(where)
         query += " RETURN p{}".format(ret)
 

--- a/hydra_agent/redis_core/graphutils_operations.py
+++ b/hydra_agent/redis_core/graphutils_operations.py
@@ -248,7 +248,7 @@ class GraphOperations():
         :parent_id: Resource ID for the parent node that had this reference
         :parent_type: Resource Type for the parent node that had this reference
         :node_url: URL Reference for resource found inside a property
-        "return: Default Redis response with amount of relations created 
+        "return: Default Redis response with amount of relations created
         """
         resource = self.get_resource(node_url)
         if resource is None:

--- a/hydra_agent/redis_core/graphutils_operations.py
+++ b/hydra_agent/redis_core/graphutils_operations.py
@@ -115,7 +115,7 @@ class GraphOperations():
                 match="collection",
                 where="id='{}'".format(redis_collection_id),
                 set="members = \"{}\"".format(str(resource["members"])))
-            return
+            return []
 
         # Third Case - When processing a valid GET that is not compatible-
         # with the Redis Hydra structure, only returns response
@@ -198,9 +198,7 @@ class GraphOperations():
         :param url: URL for the resource to fetch.
         :return: Object with resource found.
         """
-        # This is the first step to interact with Redis properly
-        # This method should eventually accept a type, a id or an url
-        # do the proper checking and then return the cached info
+        # Checking which kind of query, by URL or type
         if not url and not resource_type:
             raise Exception("ERR: You should set at least" +
                             "url OR resource_type")
@@ -211,10 +209,8 @@ class GraphOperations():
 
             # Checking if querying for cached Collection or Member
             if len(url_list) == 2:
-                entrypoint, resource_endpoint = url_aux.split('/')
-                object_id = self.vocabulary + \
-                    ":" + entrypoint + \
-                    "/" + resource_endpoint
+                # When checking for collections we will always fetch the server
+                return None
             else:
                 url_list = url.split('/', 3)
                 object_id = '/' + url_list[-1]

--- a/hydra_agent/tests/test_agent.py
+++ b/hydra_agent/tests/test_agent.py
@@ -48,7 +48,7 @@ class TestAgent(unittest.TestCase):
                         "Battery": "sensor Ex", "Direction": "North",
                         "DroneID": "sensor Ex", "Position": "model Ex",
                         "SensorStatus": "sensor Ex", "Speed": "2",
-                        "@context": "/api/contexts/StateCollection.jsonld",}
+                        "@context": "/api/contexts/StateCollection.jsonld"}
 
         get_session_mock.return_value.status_code = 200
         get_session_mock.return_value.json.return_value = state_object
@@ -93,16 +93,12 @@ class TestAgent(unittest.TestCase):
 
         simplified_collection = \
             {
-                "@context": "/serverapi/contexts/DroneCollection.jsonld",
-                "@id": "/serverapi/DroneCollection/",
+                "@context": "/api/contexts/DroneCollection.jsonld",
+                "@id": "/api/DroneCollection/",
                 "@type": "DroneCollection",
                 "members": [
                     {
-                        "@id": "/serverapi/DroneCollection/1",
-                        "@type": "Drone"
-                    },
-                    {
-                        "@id": "/serverapi/DroneCollection/2",
+                        "@id": "/api/DroneCollection/1",
                         "@type": "Drone"
                     }
                 ],
@@ -110,8 +106,17 @@ class TestAgent(unittest.TestCase):
 
         embedded_get_mock.return_value.json.return_value = \
             simplified_collection
-        get_collection = self.agent.get(collection_url)
-        self.assertEqual(type(get_collection), list)
+        get_collection_url = self.agent.get(collection_url)
+        get_collection_resource_type = self.agent.get(resource_type="Drone")
+        self.assertEqual(type(get_collection_url), list)
+        self.assertEqual(type(get_collection_resource_type), list)
+        self.assertEqual(get_collection_resource_type, get_collection_url)
+
+        get_collection_cached = self.agent.get(resource_type="Drone",
+                                               cached_limit=1)
+
+        self.assertEqual(get_collection_cached[0]["@id"],
+                         get_collection_url[0]["@id"])
 
     @patch('hydra_agent.agent.Session.get')
     @patch('hydra_agent.agent.Session.put')
@@ -143,8 +148,8 @@ class TestAgent(unittest.TestCase):
         response, new_object_url = self.agent.put(collection_url, new_object)
 
         # Assert if object was inserted queried and inserted successfully
-        get_new_object = self.agent.get(new_object_url)
-        self.assertEqual(get_new_object, new_object)
+        get_new_object_url = self.agent.get(new_object_url)
+        self.assertEqual(get_new_object_url, new_object)
 
     @patch('hydra_agent.agent.Session.get')
     @patch('hydra_agent.agent.Session.post')

--- a/hydra_agent/tests/test_agent.py
+++ b/hydra_agent/tests/test_agent.py
@@ -56,7 +56,8 @@ class TestAgent(unittest.TestCase):
                                       "StateCollection/1")
 
         responses_graph = self.agent.get(resource_type="State",
-                                         filters={"Direction": "North"})
+                                         filters={"Direction": "North"},
+                                         cached_limit=1)
         responses_graph = responses_graph[0]
         self.assertEqual(response_url, responses_graph)
 
@@ -90,9 +91,27 @@ class TestAgent(unittest.TestCase):
 
         response, new_object_url = self.agent.put(collection_url, new_object)
 
+        simplified_collection = \
+            {
+                "@context": "/serverapi/contexts/DroneCollection.jsonld",
+                "@id": "/serverapi/DroneCollection/",
+                "@type": "DroneCollection",
+                "members": [
+                    {
+                        "@id": "/serverapi/DroneCollection/1",
+                        "@type": "Drone"
+                    },
+                    {
+                        "@id": "/serverapi/DroneCollection/2",
+                        "@type": "Drone"
+                    }
+                ],
+            }
+
+        embedded_get_mock.return_value.json.return_value = \
+            simplified_collection
         get_collection = self.agent.get(collection_url)
-        get_collection = eval(get_collection["members"])
-        self.assertEqual(get_collection[0]["@id"], "/api/DroneCollection/1")
+        self.assertEqual(type(get_collection), list)
 
     @patch('hydra_agent.agent.Session.get')
     @patch('hydra_agent.agent.Session.put')

--- a/hydra_agent/tests/test_agent.py
+++ b/hydra_agent/tests/test_agent.py
@@ -2,6 +2,8 @@ import unittest
 from unittest.mock import patch, MagicMock, call
 from hydra_agent.agent import Agent
 from hydra_agent.redis_core.graphutils_operations import GraphOperations
+from hydra_agent.redis_core.redis_proxy import RedisProxy
+from redisgraph import Graph
 from hydra_agent.tests.test_examples.hydra_doc_sample import doc as drone_doc
 
 
@@ -20,10 +22,13 @@ class TestAgent(unittest.TestCase):
         get_session_mock.return_value.json.return_value = drone_doc
 
         self.agent = Agent("http://localhost:8080/api")
+        self.redis_proxy = RedisProxy()
+        self.redis_connection = self.redis_proxy.get_connection()
+        self.redis_graph = Graph("apigraph", self.redis_connection)
 
     @patch('hydra_agent.agent.Session.get')
     def test_get_url(self, get_session_mock):
-        """Tests get method from the Agent
+        """Tests get method from the Agent 
         :param get_session_mock: MagicMock object for patching session.get
         """
         state_object = {"@id": "/api/StateCollection/1", "@type": "State",
@@ -231,6 +236,52 @@ class TestAgent(unittest.TestCase):
 
         # Assert if nothing different was returned by Redis
         self.assertEqual(get_new_object, {"msg": "resource doesn't exist"})
+
+    @patch('hydra_agent.agent.Session.get')
+    @patch('hydra_agent.agent.Session.put')
+    def test_edges(self, put_session_mock, embedded_get_mock):
+        """Tests put method from the Agent
+        :param put_session_mock: MagicMock object for patching session.put
+        """
+        new_object = {"@type": "Drone", "DroneState": "/api/StateCollection/1",
+                      "name": "Smart Drone", "model": "Hydra Drone",
+                      "MaxSpeed": "999", "Sensor": "Wind"}
+
+        collection_url = "http://localhost:8080/api/DroneCollection/"
+        new_object_url = collection_url + "1"
+
+        put_session_mock.return_value.status_code = 201
+        put_session_mock.return_value.json.return_value = new_object
+        put_session_mock.return_value.headers = {'Location': new_object_url}
+
+        state_object = {"@context": "/api/contexts/StateCollection.jsonld",
+                        "@id": "/api/StateCollection/1", "@type": "State",
+                        "Battery": "sensor Ex", "Direction": "speed Ex",
+                        "DroneID": "sensor Ex", "Position": "model Ex",
+                        "SensorStatus": "sensor Ex", "Speed": "2"}
+
+        # Mocking an object to be used for a property that has an embedded link
+        embedded_get_mock.return_value.status_code = 200
+        embedded_get_mock.return_value.json.return_value = state_object
+
+        response, new_object_url = self.agent.put(collection_url, new_object)
+
+        # Checking if Drone Collection has an edge to the Drone Resource
+        query = "MATCH (p)-[r]->() WHERE p.type = 'DroneCollection' \
+            RETURN type(r)"
+        query_result = self.redis_graph.query(query)
+        self.assertEqual(query_result.result_set[0][0], 'has_Drone')
+
+        # Checking if State Collection has an edge to the State Resource
+        query = "MATCH (p)-[r]->() WHERE p.type = 'StateCollection' \
+            RETURN type(r)"
+        query_result = self.redis_graph.query(query)
+        self.assertEqual(query_result.result_set[0][0], 'has_State')
+
+        # Checking if Drone Resource has an edge to the State Resource
+        query = "MATCH (p)-[r]->() WHERE p.type = 'Drone' RETURN type(r)"
+        query_result = self.redis_graph.query(query)
+        self.assertEqual(query_result.result_set[0][0], 'has_State')
 
 if __name__ == "__main__":
     unittest.main()

--- a/hydra_agent/tests/test_agent.py
+++ b/hydra_agent/tests/test_agent.py
@@ -156,6 +156,11 @@ class TestAgent(unittest.TestCase):
         get_new_object_url = self.agent.get(new_object_url)
         self.assertEqual(get_new_object_url, new_object)
 
+        get_new_object_type = self.agent.get(resource_type="Drone",
+                                             filters={'name': "Smart Drone"},
+                                             cached_limit=1)
+        self.assertEqual(get_new_object_url, get_new_object_type[0])
+
     @patch('hydra_agent.agent.Session.get')
     @patch('hydra_agent.agent.Session.post')
     @patch('hydra_agent.agent.Session.put')

--- a/hydra_agent/tests/test_agent.py
+++ b/hydra_agent/tests/test_agent.py
@@ -28,7 +28,7 @@ class TestAgent(unittest.TestCase):
 
     @patch('hydra_agent.agent.Session.get')
     def test_get_url(self, get_session_mock):
-        """Tests get method from the Agent 
+        """Tests get method from the Agent with URL
         :param get_session_mock: MagicMock object for patching session.get
         """
         state_object = {"@id": "/api/StateCollection/1", "@type": "State",
@@ -46,7 +46,7 @@ class TestAgent(unittest.TestCase):
 
     @patch('hydra_agent.agent.Session.get')
     def test_get_class_properties(self, get_session_mock):
-        """Tests get method from the Agent
+        """Tests get method from the Agent by class name and properties
         :param get_session_mock: MagicMock object for patching session.get
         """
         state_object = {"@id": "/api/StateCollection/1", "@type": "State",
@@ -74,9 +74,9 @@ class TestAgent(unittest.TestCase):
     @patch('hydra_agent.agent.Session.get')
     @patch('hydra_agent.agent.Session.put')
     def test_get_collection(self, put_session_mock, embedded_get_mock):
-        """Tests get method from the Agent
-        :param get_processing_mock: MagicMock object to patch graphoperations
-        :param get_mock: MagicMock object for patching session.get
+        """Tests get method from the Agent when fetching collections
+        :param put_session_mock: MagicMock object for patching session.put
+        :param embedded_get_mock: MagicMock object for patching session.get
         """
         new_object = {"@type": "Drone", "DroneState": "/api/StateCollection/1",
                       "name": "Smart Drone", "model": "Hydra Drone",
@@ -133,6 +133,7 @@ class TestAgent(unittest.TestCase):
     def test_put(self, put_session_mock, embedded_get_mock):
         """Tests put method from the Agent
         :param put_session_mock: MagicMock object for patching session.put
+        :param embedded_get_mock: MagicMock object for patching session.get
         """
         new_object = {"@type": "Drone", "DroneState": "/api/StateCollection/1",
                       "name": "Smart Drone", "model": "Hydra Drone",
@@ -213,7 +214,8 @@ class TestAgent(unittest.TestCase):
                     get_session_mock):
         """Tests post method from the Agent
         :param put_session_mock: MagicMock object for patching session.put
-        :param post_session_mock: MagicMock object for patching session.post
+        :param delete_session_mock: MagicMock object to patch session.delete
+        :param get_session_mock: MagicMock object for patching session.get
         """
         new_object = {"@type": "Drone", "DroneState": "/api/StateCollection/1",
                       "name": "Smart Drone", "model": "Hydra Drone",
@@ -240,8 +242,9 @@ class TestAgent(unittest.TestCase):
     @patch('hydra_agent.agent.Session.get')
     @patch('hydra_agent.agent.Session.put')
     def test_edges(self, put_session_mock, embedded_get_mock):
-        """Tests put method from the Agent
+        """Tests to check if all edges are being created properly
         :param put_session_mock: MagicMock object for patching session.put
+        :param embedded_get_mock: MagicMock object for patching session.get
         """
         new_object = {"@type": "Drone", "DroneState": "/api/StateCollection/1",
                       "name": "Smart Drone", "model": "Hydra Drone",

--- a/hydra_agent/tests/test_agent.py
+++ b/hydra_agent/tests/test_agent.py
@@ -52,14 +52,19 @@ class TestAgent(unittest.TestCase):
 
         get_session_mock.return_value.status_code = 200
         get_session_mock.return_value.json.return_value = state_object
-        response_url = self.agent.get("http://localhost:8080/api/" + \
+        response_url = self.agent.get("http://localhost:8080/api/" +
                                       "StateCollection/1")
 
-        responses_graph = self.agent.get(resource_type="State",
+        response_cached = self.agent.get(resource_type="State",
                                          filters={"Direction": "North"},
                                          cached_limit=1)
-        responses_graph = responses_graph[0]
-        self.assertEqual(response_url, responses_graph)
+
+        response_cached = response_cached[0]
+        self.assertEqual(response_url, response_cached)
+
+        response_not_cached = self.agent.get("http://localhost:8080/api/" +
+                                             "StateCollection/1")
+        self.assertEqual(response_not_cached, response_cached)
 
     @patch('hydra_agent.agent.Session.get')
     @patch('hydra_agent.agent.Session.put')


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
Agent will search both Redis and Server for resources by type and properties. Ex.: 
print(agent.get(resource_type="Drone", filters={'name': "Drone 2"}))

### Functionality 

- Resources queried by URL will be fetched directly from Redis. If they are not yet cached, they will be fetched from the server

- Searching by type and properties will fetch from Redis considering the optional variable "cached_redis" that sets the minimum limit of cached resources you would like. If not enough resources, the search will be forward to the server. By default, for integrity purposes, it's set for sys.maxsize.

- Collections will always be fetched from Server since new members(unavailable in Redis) can always be added

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
