### PR TITLE
Fixes Travis Build Error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,19 +7,24 @@ try:
     # pip >=20
     from pip._internal.network.session import PipSession
     from pip._internal.req import parse_requirements
+    install_requires = parse_requirements('requirements.txt',session=PipSession())
+    dependencies = [str(package.requirement) for package in install_requires]
 except ImportError:
     try:
         # 10.0.0 <= pip <= 19.3.1
         from pip._internal.download import PipSession
-        from pip._internal.req import parse_requirements
+        from pip._internal.req import parse_requirements       
     except ImportError:
         # pip <= 9.0.3
         from pip.download import PipSession
         from pip.req import parse_requirements
 
+    install_requires = parse_requirements('requirements.txt',session=PipSession())
+    dependencies = [str(package.req) for package in install_requires]
 
-install_requires = parse_requirements('requirements.txt',session=PipSession())
-dependencies = [str(package.req) for package in install_requires]
+for package_index in range(len(dependencies)):
+  if dependencies[package_index].startswith('git+'):
+      dependencies[package_index] = dependencies[package_index].split('=')[1]
 
 setup(name='hydra-python-agent',
       include_package_data=True,


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
Fixes #143 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
This PR fixes the travis build error on dev versions of python. On newer versions of pip, package.req is no longer supported.

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->
added parsing facility of requirements for newer versions of pip. 

<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->

<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
