### PR TITLE
Discover api-doc url from Link header

### DIFF
--- a/hydra_agent/agent.py
+++ b/hydra_agent/agent.py
@@ -44,9 +44,15 @@ class Agent(Session, socketio.ClientNamespace, socketio.Client):
         if hasattr(self, 'api_doc'):
             return self.api_doc 
         else:
-            jsonld_api_doc = super().get(self.entrypoint_url + '/vocab').json()
-            self.api_doc = doc_maker.create_doc(jsonld_api_doc)
-            return self.api_doc 
+            try:
+                res = super().get(self.entrypoint_url)
+                api_doc_url = res.links['http://www.w3.org/ns/hydra/core#apiDocumentation']['url']
+                jsonld_api_doc = super().get(api_doc_url).json()
+                self.api_doc = doc_maker.create_doc(jsonld_api_doc)
+                return self.api_doc
+            except:
+                print("Error parsing your API Documentation")
+                raise
 
     def initialize_graph(self) -> None:
         """Initialize the Graph on Redis based on ApiDoc


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #102 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
Instead of appending 'vocab' after entry point url, this PR retrieves api doc url from the Link header according to the Hydra spec. 
### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->
Added parsing of Link header to discover the API DOC URL.


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
