### PR TITLE
Add partial collection Paginator

### DIFF
--- a/hydra_agent/agent.py
+++ b/hydra_agent/agent.py
@@ -9,8 +9,7 @@ from typing import Union, Tuple
 from requests import Session
 import json
 from hydra_agent.helpers import expand_template
-
-from hydra_agent.partial_collection_crawler import PartialCollectionCrawler
+from hydra_agent.collection_paginator import Paginator
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__file__)
 
@@ -79,9 +78,25 @@ class Agent(Session, socketio.ClientNamespace, socketio.Client):
         :param resource_type: Resource object type
         :param filters: filters to apply when searching, resources properties
         :param cached_limit : Minimum amount of resources to be fetched
-        :param follow_partial_links: If set to True, Crawler can crawl pages.
+        :param follow_partial_links: If set to True, Paginator can go through pages.
         :return: Dict when one object or a list when multiple targerted objects
         :return: Iterator when param follow_partial_links is set to true
+                    Iterator will be returned.
+                    Usage:
+                    paginator = agent.get('http://localhost:8080/serverapi/DroneCollection', \
+                                        follow_partial_links=True)
+                    To paginate forward:
+                    ford = paginator.initialize_forward()
+                    To get the members of first page:
+                    next(ford)
+                    To get the members of second page:
+                    next(ford)
+                    To paginate Backwards:
+                    back = paginator.initialize_backward()
+                    To get the members of prev page:
+                    next(back)
+                    To Jump:
+                    paginator.jump_to_page(2) 
         """
         redis_response = self.graph_operations.get_resource(url, resource_type,
                                                             filters)
@@ -116,25 +131,7 @@ class Agent(Session, socketio.ClientNamespace, socketio.Client):
                 return response.json()
             else:
                 if follow_partial_links:
-                    """
-                    Iterator will be returned.
-                    Usage:
-                    crawler = agent.get('http://localhost:8080/serverapi/DroneCollection', \
-                                        follow_partial_links=True)
-                    To crawl forward:
-                    ford = crawler.initialize_forward()
-                    To get the members of first page:
-                    next(ford)
-                    To get the members of second page:
-                    next(ford)
-                    To Crawl Backwards:
-                    back = crawler.initialize_backward()
-                    To get the members of prev page:
-                    next(back)
-                    To Jump:
-                    crawler.jumpToPage(2) 
-                    """
-                    return PartialCollectionCrawler(response=response.json())
+                    return Paginator(response=response.json())
                 else:
                     return response.json()
         else:

--- a/hydra_agent/partial_collection_crawler.py
+++ b/hydra_agent/partial_collection_crawler.py
@@ -1,0 +1,95 @@
+from requests import get
+
+
+class PartialCollectionCrawler:
+    """
+    Crawler for Crawling Collections. 
+    It can move forwards, backwards or can jump to specific page
+    """
+
+    def __init__(self, response):
+        self.response = response
+        self.base_url = 'http://localhost:8080'
+
+    def initialize_forward(self):
+        """
+        Initializes the crawler to move forwards.
+        :returns: Iterator
+        """
+        view = self.response['view']
+        present_page = view['@id']
+        while True:
+            self.response = get(self.base_url + present_page).json()
+            yield self.response['members']
+            view = self.response['view']
+            print('view')
+            if 'next' in view:
+                present_page = view['next']
+            else:
+                raise StopIteration("No more collection pages")
+
+    def initialize_backward(self):
+        """
+        Initializes the crawler to move backwards.
+        :returns: Iterator
+        """
+        view = self.response['view']
+        present_page = view['@id']
+        while True:
+            self.response = get(self.base_url+present_page).json()
+            yield self.response['members']
+            view = self.response['view']
+            if 'previous' in view:
+                present_page = view['previous']
+            else:
+                raise StopIteration("No more collection pages")
+
+    def jumpToPage(self, page):
+        """
+        Jumps to a specified page. 
+        :params page: Page number to jump
+        :returns members: Members of collection of that page.
+        """
+        try:
+            url = self.base_url + self.response['@id'] + '?page=' + str(page)
+            response = get(url).json()
+            return response['members']
+        except KeyError:
+            print('No such page exists.')
+            raise
+
+    def jumpToLastPage(self):
+        """
+        Jumps to Last page of Collection
+        :returns members of last page of Partial Collection
+        """
+        try:
+            url = self.base_url + self.response['view']['last']
+            response = get(url).json()
+            return response['members']
+        except KeyError:
+            print("No last item in view")
+            raise
+
+    def totalItems(self):
+        """returns total number of items of collection
+        :return: Total number of items in collection
+        """
+        try:
+            return self.response['totalItems']
+        except KeyError:
+            print("No totalItem provided")
+            raise
+
+    def total_pages(self):
+        """
+        Returns total Number of pages in the Collection
+        :returns: total number of pages in the Partial Collection
+        """
+        try:
+            last_page_url = self.response['view']['last']
+            indexPage = last_page_url.index("page=")
+            return last_page_url[indexPage + 5]
+        except KeyError:
+            print("Unable to find last page")
+            raise


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Fixes #

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
When the collection has many members, hydrus returns them in several pages. Earlier there was no way to get all the members of collections by crawling them. This PR adds the functionality of crawling forwards, backwards and jumping to a specific page.  

### Change logs
Added Pagination functionality in Agent.
<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
