### PR TITLE
Return Full Collection instead of just members

### DIFF
--- a/hydra_agent/agent.py
+++ b/hydra_agent/agent.py
@@ -102,7 +102,7 @@ class Agent(Session, socketio.ClientNamespace, socketio.Client):
             if response.json()['@type'] in self.api_doc.parsed_classes:
                 return response.json()
             else:
-                return response.json()['members']
+                return response.json()
         else:
             return response.text
 

--- a/hydra_agent/agent.py
+++ b/hydra_agent/agent.py
@@ -92,7 +92,7 @@ class Agent(Session, socketio.ClientNamespace, socketio.Client):
             url = self.entrypoint_url + "/" + resource_type + "Collection"
             response = super().get(url, params=filters)
         else:
-            response = super().get(url)
+            response = super().get(url, params=filters)
 
         if response.status_code == 200:
             # Graph_operations returns the embedded resources if finding any

--- a/hydra_agent/tests/test_agent.py
+++ b/hydra_agent/tests/test_agent.py
@@ -185,9 +185,9 @@ class TestAgent(unittest.TestCase):
                                              cached_limit=1)
         self.assertEqual(get_new_object_url, get_new_object_type[0])
 
-    @ patch('hydra_agent.agent.Session.get')
-    @ patch('hydra_agent.agent.Session.post')
-    @ patch('hydra_agent.agent.Session.put')
+    @patch('hydra_agent.agent.Session.get')
+    @patch('hydra_agent.agent.Session.post')
+    @patch('hydra_agent.agent.Session.put')
     def test_post(self, put_session_mock, post_session_mock,
                   embedded_get_mock):
         """Tests post method from the Agent
@@ -225,9 +225,9 @@ class TestAgent(unittest.TestCase):
         get_new_object = self.agent.get(new_object_url)
         self.assertEqual(get_new_object, new_object)
 
-    @ patch('hydra_agent.agent.Session.get')
-    @ patch('hydra_agent.agent.Session.delete')
-    @ patch('hydra_agent.agent.Session.put')
+    @patch('hydra_agent.agent.Session.get')
+    @patch('hydra_agent.agent.Session.delete')
+    @patch('hydra_agent.agent.Session.put')
     def test_delete(self, put_session_mock, delete_session_mock,
                     get_session_mock):
         """Tests post method from the Agent
@@ -257,8 +257,8 @@ class TestAgent(unittest.TestCase):
         # Assert if nothing different was returned by Redis
         self.assertEqual(get_new_object, {"msg": "resource doesn't exist"})
 
-    @ patch('hydra_agent.agent.Session.get')
-    @ patch('hydra_agent.agent.Session.put')
+    @patch('hydra_agent.agent.Session.get')
+    @patch('hydra_agent.agent.Session.put')
     def test_edges(self, put_session_mock, embedded_get_mock):
         """Tests to check if all edges are being created properly
         :param put_session_mock: MagicMock object for patching session.put

--- a/hydra_agent/tests/test_agent.py
+++ b/hydra_agent/tests/test_agent.py
@@ -114,21 +114,37 @@ class TestAgent(unittest.TestCase):
                         "@type": "Drone"
                     }
                 ],
+                "search": {
+                    "@type": "hydra:IriTemplate",
+                    "hydra:mapping": [{
+                        "@type": "hydra:IriTemplateMapping",
+                        "hydra:property": "http://auto.schema.org/speed",
+                        "hydra:required": False,
+                        "hydra:variable": "DroneState[Speed]"}
+                    ],
+                    "hydra:template": "/serverapi/Drone(DroneState[Speed])",
+                    "hydra:variableRepresentation": "hydra:BasicRepresentation",
+                },
+                "totalItems": 1,
+                "view": {
+                    "@id": "/serverapi/DroneCollection?page=1",
+                    "@type": "PartialCollectionView",
+                    "first": "/serverapi/DroneCollection?page=1",
+                    "last": "/serverapi/DroneCollection?page=1",
+                    "next": "/serverapi/DroneCollection?page=1"
+                }
             }
 
-        embedded_get_mock.return_value.json.return_value = \
-            simplified_collection
+        embedded_get_mock.return_value.json.return_value = simplified_collection
         get_collection_url = self.agent.get(collection_url)
         get_collection_resource_type = self.agent.get(resource_type="Drone")
-        self.assertEqual(type(get_collection_url), list)
-        self.assertEqual(type(get_collection_resource_type), list)
+        self.assertEqual(type(get_collection_url), dict)
+        self.assertEqual(type(get_collection_resource_type), dict)
         self.assertEqual(get_collection_resource_type, get_collection_url)
-
         get_collection_cached = self.agent.get(resource_type="Drone",
                                                cached_limit=1)
-
         self.assertEqual(get_collection_cached[0]["@id"],
-                         get_collection_url[0]["@id"])
+                         get_collection_url['members'][0]["@id"])
 
     @patch('hydra_agent.agent.Session.get')
     @patch('hydra_agent.agent.Session.put')
@@ -169,9 +185,9 @@ class TestAgent(unittest.TestCase):
                                              cached_limit=1)
         self.assertEqual(get_new_object_url, get_new_object_type[0])
 
-    @patch('hydra_agent.agent.Session.get')
-    @patch('hydra_agent.agent.Session.post')
-    @patch('hydra_agent.agent.Session.put')
+    @ patch('hydra_agent.agent.Session.get')
+    @ patch('hydra_agent.agent.Session.post')
+    @ patch('hydra_agent.agent.Session.put')
     def test_post(self, put_session_mock, post_session_mock,
                   embedded_get_mock):
         """Tests post method from the Agent
@@ -209,9 +225,9 @@ class TestAgent(unittest.TestCase):
         get_new_object = self.agent.get(new_object_url)
         self.assertEqual(get_new_object, new_object)
 
-    @patch('hydra_agent.agent.Session.get')
-    @patch('hydra_agent.agent.Session.delete')
-    @patch('hydra_agent.agent.Session.put')
+    @ patch('hydra_agent.agent.Session.get')
+    @ patch('hydra_agent.agent.Session.delete')
+    @ patch('hydra_agent.agent.Session.put')
     def test_delete(self, put_session_mock, delete_session_mock,
                     get_session_mock):
         """Tests post method from the Agent
@@ -241,8 +257,8 @@ class TestAgent(unittest.TestCase):
         # Assert if nothing different was returned by Redis
         self.assertEqual(get_new_object, {"msg": "resource doesn't exist"})
 
-    @patch('hydra_agent.agent.Session.get')
-    @patch('hydra_agent.agent.Session.put')
+    @ patch('hydra_agent.agent.Session.get')
+    @ patch('hydra_agent.agent.Session.put')
     def test_edges(self, put_session_mock, embedded_get_mock):
         """Tests to check if all edges are being created properly
         :param put_session_mock: MagicMock object for patching session.put
@@ -287,6 +303,7 @@ class TestAgent(unittest.TestCase):
         query = "MATCH (p)-[r]->() WHERE p.type = 'Drone' RETURN type(r)"
         query_result = self.redis_graph.query(query)
         self.assertEqual(query_result.result_set[0][0], 'has_State')
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- Please create/claim an issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->

Addresses #148 

### Checklist
- [x] My branch is up-to-date with upstream/develop branch.
- [x] Everything works and tested for Python 3.5.2 and above.

### Description
<!-- Describe about what this PR does, previous state and new state of the output -->
* Previously agent on get request on collection endpoint returned only members of collections.
* This PR enables agent to return whole collection response body when GET is invoked. 
* Also add params when collection endpoints are invoked.
### Change logs

* Return whole collection body instead of just members
* Add params in get request.
* Fix tests to support this feature.
<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
